### PR TITLE
Decode html entities when verifying IPN request hash

### DIFF
--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -76,10 +76,10 @@ abstract class AbstractRequest  extends \Omnipay\Common\Message\AbstractRequest 
             if (!in_array($key, $skip)) {
                 if (is_array($item)) {
                     foreach($item as $i) {
-                        $hash_source .= strlen(''.stripslashes($i)) . $i;
+                        $hash_source .= strlen(''.$i) . $i;
                     }
                 } else {
-                    $hash_source .= strlen(''.stripslashes($item)) . $item;
+                    $hash_source .= strlen(''.$item) . $item;
                 }
             }
         }

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -76,10 +76,10 @@ abstract class AbstractRequest  extends \Omnipay\Common\Message\AbstractRequest 
             if (!in_array($key, $skip)) {
                 if (is_array($item)) {
                     foreach($item as $i) {
-                        $hash_source .= strlen(''.$i) . $i;
+                        $hash_source .= strlen(''.stripslashes($i)) . $i;
                     }
                 } else {
-                    $hash_source .= strlen(''.$item) . $item;
+                    $hash_source .= strlen(''.stripslashes($item)) . $item;
                 }
             }
         }

--- a/src/Message/IPNResponse.php
+++ b/src/Message/IPNResponse.php
@@ -25,7 +25,7 @@ class IPNResponse extends AbstractResponse {
          * before calculating the hash. This results in signature mismatch when the payload contains
          * encoded html entities. Only trying this if the original match fails here to keep it backward compatible.
          */
-        if (!$match && is_array($data)) {
+        if (!$match && is_array($this->data)) {
             $modifiedArray = $this->data;
             array_walk_recursive($modifiedArray, function(&$item) {
                 if (is_string($item)) {

--- a/src/Message/IPNResponse.php
+++ b/src/Message/IPNResponse.php
@@ -22,10 +22,10 @@ class IPNResponse extends AbstractResponse {
         $match = $hash === $this->data['HASH'];
         /**
          * The docs do not explicitly state this, but it seems like they are decoding html entities
-         * before calculating the hash.  Only trying this if the original match fails here to keep
-         * it backward compatible.
+         * before calculating the hash. This results in signature mismatch when the payload contains
+         * encoded html entities. Only trying this if the original match fails here to keep it backward compatible.
          */
-        if (!$match) {
+        if (!$match && is_array($data)) {
             $modifiedArray = $this->data;
             array_walk_recursive($modifiedArray, function(&$item) {
                 if (is_string($item)) {


### PR DESCRIPTION
Updates verifyHash in IPNResponse to check a second time after decoding html entities from the payload if the hash does not match. 

### Explanation
The way that the hash is being calculated does not match the hash returned by simple pay if the payload contains encoded html entities. For example, if the payload for an incoming IPN request contains an address with `&quot;` in the string, the hash calculated here will not match the one returned by simple pay, and `verifyHash` will return false for the IPN request.  However if the values in the payload are html_entity_decoded before calculating the hash, the hash will match.